### PR TITLE
Nit: Link to NPM updated in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://raw.githubusercontent.com/PeculiarVentures/ASN1.js/master/LICENSE)  [![CircleCI](https://circleci.com/gh/PeculiarVentures/ASN1.js.svg?style=svg)](https://circleci.com/gh/PeculiarVentures/ASN1.js)
 [![NPM version](https://badge.fury.io/js/asn1js.png)](http://badge.fury.io/js/asn1js)
 
-[![NPM](https://nodei.co/npm-dl/asn1js.png?months=3&height=2)](https://nodei.co/npm/ASN1js/)
+[![NPM](https://nodei.co/npm-dl/asn1js.png?months=3&height=2)](https://nodei.co/npm/asn1js/)
 
 Abstract Syntax Notation One (ASN.1) is a standard and notation that describes rules and structures for representing, encoding, transmitting, and decoding data in telecommunications and computer networking. [ASN1js][] is a pure JavaScript library implementing this standard.  ASN.1 is the basis of all X.509 related data structures and numerous other protocols used on the web.
 


### PR DESCRIPTION
Broken link in readme fixed.
Was: https://www.npmjs.com/package/ASN1js
Now: https://www.npmjs.com/package/asn1js