### PR TITLE
fix license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "prepublishOnly": "npm run build"
   },
   "version": "2.0.21",
-  "license": "MIT"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
The LICENSE file in this repo is a BSD-3-Clause license, not MIT.
Updating the package.json to reflect the reality of the source.

For reference, here's the licenses from [OSI](https://opensource.org/) where you can see that
the LICENSE file is verbatim [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause) and not [MIT](https://opensource.org/licenses/MIT).