### PR TITLE
Fix off-by-one bug when calculating month in GeneralizedTime

### DIFF
--- a/src/asn1.js
+++ b/src/asn1.js
@@ -4915,7 +4915,7 @@ export class GeneralizedTime extends VisibleString
 		//region Get final date
 		if(isUTC === false)
 		{
-			const tempDate = new Date(this.year, this.month, this.day, this.hour, this.minute, this.second, this.millisecond);
+			const tempDate = new Date(this.year, this.month - 1, this.day, this.hour, this.minute, this.second, this.millisecond);
 
 			this.year = tempDate.getUTCFullYear();
 			this.month = tempDate.getUTCMonth();


### PR DESCRIPTION
I checked other places where `Date` is initialised, and they're all subtracting 1 from the month.