### PR TITLE
fix: empty bitstring ber encoding output should be 0x030100

### DIFF
--- a/src/internals/LocalBitStringValueBlock.ts
+++ b/src/internals/LocalBitStringValueBlock.ts
@@ -6,7 +6,7 @@ import {
 import { localFromBER } from "../parser";
 import type { BitString } from "../BitString";
 import {
-  BIT_STRING_NAME, EMPTY_BUFFER, END_OF_CONTENT_NAME,
+  BIT_STRING_NAME, END_OF_CONTENT_NAME,
 } from "./constants";
 import {
   LocalConstructedValueBlockParams, LocalConstructedValueBlockJson, LocalConstructedValueBlock,
@@ -139,7 +139,9 @@ export class LocalBitStringValueBlock extends
     }
 
     if (!this.valueHexView.byteLength) {
-      return EMPTY_BUFFER;
+      const empty = new Uint8Array(1);
+      empty[0] = 0; // unusedBits
+      return empty.buffer;
     }
 
     const retView = new Uint8Array(this.valueHexView.length + 1);

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -83,6 +83,10 @@ describe("ASN types", () => {
       const asn = asn1js.fromBER(pvtsutils.Convert.FromHex("0300"));
       assert.ok(asn.result instanceof asn1js.BitString);
     });
+    it("parse empty", () => {
+      const asn = asn1js.fromBER(pvtsutils.Convert.FromHex("030100"));
+      assert.ok(asn.result instanceof asn1js.BitString);
+    });    
     it("incorrect unused bits", () => {
       const asn = asn1js.fromBER(pvtsutils.Convert.FromHex("030208ff"));
       assert.strictEqual(asn.offset, -1);
@@ -96,7 +100,7 @@ describe("ASN types", () => {
     describe("toBER", () => {
       it("default", () => {
         const asn = new asn1js.BitString();
-        assert.strictEqual(asn.toString("hex"), "0300");
+        assert.strictEqual(asn.toString("hex"), "030100");
       });
 
       it("primitive", () => {


### PR DESCRIPTION
Closes #122 

Updates `LocalBitStringValueBlock.ts` to return `0x030100` for empty bitstring and update the `types.spec.ts` with the new expectation.