### PR TITLE
Add resource limits to fromBER

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@
 Abstract Syntax Notation One (ASN.1) is a standard and notation that describes rules and structures for representing, encoding, transmitting, and decoding data in telecommunications and computer networking. [ASN1js] is a pure JavaScript library implementing this standard.  ASN.1 is the basis of all X.509 related data structures and numerous other protocols used on the web.
 
 ## Important Information for ASN1.js V1 Users
+
 ASN1.js V2 (ES2015 version) is **incompatible** with ASN1.js V1 code.
 
 ## Introduction
 
-[ASN1js] is the first library for [BER] encoding/decoding in Javascript designed for browser use. [BER] is the basic encoding rules for [ASN.1] that all others are based on, [DER] is the encoding rules used by PKI applications - it is a subset of [BER]. The [ASN1js] library was tested against [freely available ASN.1:2008 test suite], with some limitations related to JavaScript language. 
+[ASN1js] is the first library for [BER] encoding/decoding in Javascript designed for browser use. [BER] is the basic encoding rules for [ASN.1] that all others are based on, [DER] is the encoding rules used by PKI applications - it is a subset of [BER]. The [ASN1js] library was tested against [freely available ASN.1:2008 test suite], with some limitations related to JavaScript language.
 
 ## Features of the library
 
@@ -39,7 +40,7 @@ ASN1.js V2 (ES2015 version) is **incompatible** with ASN1.js V1 code.
 * Has special types to work with ASN.1 schemas:
   * Any
   * Choice
-  * Repeated 
+  * Repeated
 * User can name any block inside ASN.1 schema and easily get information by name;
 * Ability to parse internal data inside a primitively encoded data types and automatically validate it against special schema;
 * All types inside library are dynamic;
@@ -49,6 +50,7 @@ ASN1.js V2 (ES2015 version) is **incompatible** with ASN1.js V1 code.
 ## Examples
 
 ### How to create new ASN. structures
+
 ```javascript
 var sequence = new asn1js.Sequence();
 sequence.valueBlock.value.push(new asn1js.Integer({ value: 1 }));
@@ -77,6 +79,7 @@ current_size = sequence_buffer.byteLength;
 ```
 
 ### How to create new ASN.1 structures by calling constructors with parameters
+
 ```javascript
 var sequence2 = new asn1js.Sequence({
   value: [
@@ -89,7 +92,8 @@ var sequence2 = new asn1js.Sequence({
 });
 ```
 
-### How to validate ASN.1 against pre-defined schema 
+### How to validate ASN.1 against pre-defined schema
+
 ```javascript
 var asn1_schema = new asn1js.Sequence({
   name: "block1",
@@ -110,7 +114,8 @@ var variant1_result = variant1.result; // Verified decoded data with all block n
 ```
 
 ### How to use "internal schemas" for primitively encoded data types
-```javascript 
+
+```javascript
 var primitive_octetstring = new asn1js.OctetString({ valueHex: encoded_sequence }); // Create a primitively encoded OctetString where internal data is an encoded Sequence
 
 var asn1_schema_internal = new asn1js.OctetString({
@@ -133,13 +138,28 @@ var variant6_block2_tag_num = variant6.result.block2.idBlock.tagNumber;
 
 More examples could be found in "examples" directory or inside [PKIjs] library.
 
-## Related source code 
+## Parsing Untrusted Input
+
+`fromBER()` accepts optional parser resource limits for untrusted ASN.1 input.
+
+```typescript
+const asn1 = asn1js.fromBER(inputBuffer, {
+  maxDepth: 100,
+  maxNodes: 10000,
+  maxContentLength: 16 * 1024 * 1024,
+});
+```
+
+When any limit is exceeded the parser returns a normal `FromBerResult` error instead of exhausting the JavaScript stack or continuing to parse excessive input.
+
+## Related source code
 
 * [C++ ASN1:2008 BER coder/decoder](https://github.com/YuryStrozhevsky/C-plus-plus-ASN.1-2008-coder-decoder) - the "father" of [ASN1js] project;
 * [Freely available ASN.1:2008 test suite](https://github.com/YuryStrozhevsky/ASN1-2008-free-test-suite) - the suite which can help you to validate (and better understand) any ASN.1 coder/decoder;
 * [NPM package for ASN.1:2008 test suite](https://github.com/YuryStrozhevsky/asn1-test-suite)
 
 ## Suitability
+
 There are several commercial products, enterprise solutions as well as open source project based on versions of ASN1js. You should, however, do your own code and security review before utilization in a production application before utilizing any open source library to ensure it will meet your needs.
 
 ## License
@@ -150,31 +170,30 @@ All rights reserved.
 
 Author 2014-2018, [Yury Strozhevsky](http://www.strozhevsky.com/).
 
-Redistribution and use in source and binary forms, with or without modification, 
+Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, 
+1. Redistributions of source code must retain the above copyright notice,
    this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, 
-   this list of conditions and the following disclaimer in the documentation 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors 
-   may be used to endorse or promote products derived from this software without 
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
    specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-OF SUCH DAMAGE. 
-
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
 
 [ASN.1]: http://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One
 [ASN1js]: http://asn1js.org/

--- a/src/BaseBlock.ts
+++ b/src/BaseBlock.ts
@@ -14,6 +14,7 @@ import { ViewWriter } from "./ViewWriter";
 import { ValueBlock, ValueBlockJson } from "./ValueBlock";
 import { EMPTY_BUFFER, EMPTY_STRING } from "./internals/constants";
 import { typeStore } from "./TypeStore";
+import type { FromBerContext } from "./parser";
 
 export interface IBaseBlock {
   name: string;
@@ -66,10 +67,10 @@ export class BaseBlock<T extends ValueBlock = ValueBlock, J extends ValueBlockJs
     this.valueBlock = valueBlockType ? new valueBlockType(parameters) : new ValueBlock(parameters) as unknown as T;
   }
 
-  public fromBER(inputBuffer: Uint8Array, inputOffset: number, inputLength: number): number {
+  public fromBER(inputBuffer: Uint8Array, inputOffset: number, inputLength: number, context?: FromBerContext): number {
     const resultOffset = this.valueBlock.fromBER(inputBuffer, inputOffset, (this.lenBlock.isIndefiniteForm)
       ? inputLength
-      : this.lenBlock.length);
+      : this.lenBlock.length, context);
     if (resultOffset === -1) {
       this.error = this.valueBlock.error;
 

--- a/src/BitString.ts
+++ b/src/BitString.ts
@@ -7,6 +7,7 @@ import {
   LocalBitStringValueBlockParams, LocalBitStringValueBlock, LocalBitStringValueBlockJson,
 } from "./internals/LocalBitStringValueBlock";
 import { typeStore } from "./TypeStore";
+import type { FromBerContext } from "./parser";
 
 export interface BitStringParams extends BaseBlockParams, LocalBitStringValueBlockParams { }
 export type BitStringJson = BaseBlockJson<LocalBitStringValueBlockJson>;
@@ -40,11 +41,16 @@ export class BitString extends BaseBlock<LocalBitStringValueBlock, LocalBitStrin
     this.idBlock.tagNumber = 3; // BitString
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer | Uint8Array,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     this.valueBlock.isConstructed = this.idBlock.isConstructed;
     this.valueBlock.isIndefiniteForm = this.lenBlock.isIndefiniteForm;
 
-    return super.fromBER(inputBuffer as Uint8Array, inputOffset, inputLength);
+    return super.fromBER(inputBuffer as Uint8Array, inputOffset, inputLength, context);
   }
 
   protected override onAsciiEncoding(): string {

--- a/src/Constructed.ts
+++ b/src/Constructed.ts
@@ -5,6 +5,7 @@ import {
   LocalConstructedValueBlock, LocalConstructedValueBlockJson, LocalConstructedValueBlockParams,
 } from "./internals/LocalConstructedValueBlock";
 import { typeStore } from "./TypeStore";
+import type { FromBerContext } from "./parser";
 
 export interface ConstructedParams extends BaseBlockParams, LocalConstructedValueBlockParams { }
 export type ConstructedJson = BaseBlockJson<LocalConstructedValueBlockJson>;
@@ -22,13 +23,19 @@ export class Constructed extends BaseBlock<LocalConstructedValueBlock, LocalCons
     this.idBlock.isConstructed = true;
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer | Uint8Array,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     this.valueBlock.isIndefiniteForm = this.lenBlock.isIndefiniteForm;
 
     const resultOffset = this.valueBlock.fromBER(
       inputBuffer,
       inputOffset,
-      (this.lenBlock.isIndefiniteForm) ? inputLength : this.lenBlock.length);
+      (this.lenBlock.isIndefiniteForm) ? inputLength : this.lenBlock.length,
+      context);
     if (resultOffset === -1) {
       this.error = this.valueBlock.error;
 

--- a/src/HexBlock.ts
+++ b/src/HexBlock.ts
@@ -55,7 +55,12 @@ export function HexBlock<T extends LocalBaseBlockConstructor>(BaseClass: T) {
       this.valueHexView = params.valueHex ? pvtsutils.BufferSourceConverter.toUint8Array(params.valueHex) : EMPTY_VIEW;
     }
 
-    public fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+    public fromBER(
+      inputBuffer: ArrayBuffer | Uint8Array,
+      inputOffset: number,
+      inputLength: number,
+      _context?: unknown,
+    ): number {
       // Basic check for parameters
       const view = inputBuffer instanceof ArrayBuffer ? new Uint8Array(inputBuffer) : inputBuffer;
       if (!checkBufferParams(this, view, inputOffset, inputLength)) {

--- a/src/OctetString.ts
+++ b/src/OctetString.ts
@@ -7,8 +7,12 @@ import {
   LocalOctetStringValueBlockParams, LocalOctetStringValueBlock, LocalOctetStringValueBlockJson,
 } from "./internals/LocalOctetStringValueBlock";
 import { OCTET_STRING_NAME } from "./internals/constants";
-import { localFromBER } from "./parser";
+import {
+  createFromBerContext,
+  localFromBERWithChildContext,
+} from "./parser";
 import { typeStore } from "./TypeStore";
+import type { FromBerContext } from "./parser";
 
 export interface OctetStringParams extends BaseBlockParams, LocalOctetStringValueBlockParams { }
 export type OctetStringJson = BaseBlockJson<LocalOctetStringValueBlockJson>;
@@ -42,7 +46,12 @@ export class OctetString extends BaseBlock<LocalOctetStringValueBlock, LocalOcte
     this.idBlock.tagNumber = 4; // OctetString
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer | Uint8Array,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     this.valueBlock.isConstructed = this.idBlock.isConstructed;
     this.valueBlock.isIndefiniteForm = this.lenBlock.isIndefiniteForm;
 
@@ -62,7 +71,8 @@ export class OctetString extends BaseBlock<LocalOctetStringValueBlock, LocalOcte
       const buf = view.subarray(inputOffset, inputOffset + inputLength);
       try {
         if (buf.byteLength) {
-          const asn = localFromBER(buf, 0, buf.byteLength);
+          const parseContext = context ?? createFromBerContext();
+          const asn = localFromBERWithChildContext(buf, 0, buf.byteLength, parseContext);
           if (asn.offset !== -1 && asn.offset === inputLength) {
             this.valueBlock.value = [asn.result as OctetString];
           }
@@ -72,7 +82,7 @@ export class OctetString extends BaseBlock<LocalOctetStringValueBlock, LocalOcte
       }
     }
 
-    return super.fromBER(inputBuffer as Uint8Array, inputOffset, inputLength);
+    return super.fromBER(inputBuffer as Uint8Array, inputOffset, inputLength, context);
   }
 
   protected override onAsciiEncoding(): string {

--- a/src/ValueBlock.ts
+++ b/src/ValueBlock.ts
@@ -9,7 +9,12 @@ export type ValueBlockJson = internals.LocalBaseBlockJson;
 export class ValueBlock extends internals.LocalBaseBlock implements IValueBlock, IBerConvertible {
   public static override NAME = "valueBlock";
 
-  public fromBER(_inputBuffer: ArrayBuffer | Uint8Array, _inputOffset: number, _inputLength: number): number {
+  public fromBER(
+    _inputBuffer: ArrayBuffer | Uint8Array,
+    _inputOffset: number,
+    _inputLength: number,
+    _context?: unknown,
+  ): number {
     throw TypeError("User need to make a specific function in a class which extends 'ValueBlock'");
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,13 @@ export * from "./Repeated";
 // special
 export * from "./RawData";
 
-export { FromBerResult, fromBER } from "./parser";
+export {
+  DEFAULT_MAX_CONTENT_LENGTH,
+  DEFAULT_MAX_DEPTH,
+  DEFAULT_MAX_NODES,
+  FromBerOptions,
+  FromBerResult,
+  fromBER,
+} from "./parser";
 export * from "./schema";
 export { AsnType } from "./TypeStore";

--- a/src/internals/LocalBitStringValueBlock.ts
+++ b/src/internals/LocalBitStringValueBlock.ts
@@ -3,8 +3,12 @@ import { ViewWriter } from "../ViewWriter";
 import {
   HexBlockJson, HexBlockParams, HexBlock,
 } from "../HexBlock";
-import { localFromBER } from "../parser";
+import {
+  createFromBerContext,
+  localFromBERWithChildContext,
+} from "../parser";
 import type { BitString } from "../BitString";
+import type { FromBerContext } from "../parser";
 import { BIT_STRING_NAME, END_OF_CONTENT_NAME } from "./constants";
 import {
   LocalConstructedValueBlockParams, LocalConstructedValueBlockJson, LocalConstructedValueBlock,
@@ -43,7 +47,12 @@ export class LocalBitStringValueBlock extends
     this.blockLength = this.valueHexView.byteLength;
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer | Uint8Array,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     // Ability to decode zero-length BitString value
     if (!inputLength) {
       return inputOffset;
@@ -53,7 +62,13 @@ export class LocalBitStringValueBlock extends
 
     // If the BIT STRING supposed to be a constructed value
     if (this.isConstructed) {
-      resultOffset = LocalConstructedValueBlock.prototype.fromBER.call(this, inputBuffer, inputOffset, inputLength);
+      resultOffset = LocalConstructedValueBlock.prototype.fromBER.call(
+        this,
+        inputBuffer,
+        inputOffset,
+        inputLength,
+        context,
+      );
       if (resultOffset === -1)
         return resultOffset;
 
@@ -110,7 +125,8 @@ export class LocalBitStringValueBlock extends
       const buf = intBuffer.subarray(1);
       try {
         if (buf.byteLength) {
-          const asn = localFromBER(buf, 0, buf.byteLength);
+          const parseContext = context ?? createFromBerContext();
+          const asn = localFromBERWithChildContext(buf, 0, buf.byteLength, parseContext);
           if (asn.offset !== -1 && asn.offset === (inputLength - 1)) {
             this.value = [asn.result as BitString];
           }

--- a/src/internals/LocalConstructedValueBlock.ts
+++ b/src/internals/LocalConstructedValueBlock.ts
@@ -2,8 +2,12 @@ import * as pvtsutils from "pvtsutils";
 import type { BaseBlock } from "../BaseBlock";
 import { ValueBlock, ValueBlockParams } from "../ValueBlock";
 import { ViewWriter } from "../ViewWriter";
-import { localFromBER } from "../parser";
+import {
+  createFromBerContext,
+  localFromBERWithChildContext,
+} from "../parser";
 import type { Any } from "../Any";
+import type { FromBerContext } from "../parser";
 import { checkBufferParams } from "./utils";
 import { EMPTY_BUFFER, END_OF_CONTENT_NAME } from "./constants";
 import { LocalBaseBlockJson } from "./LocalBaseBlock";
@@ -46,8 +50,14 @@ export class LocalConstructedValueBlock extends ValueBlock implements ILocalCons
     this.isIndefiniteForm = isIndefiniteForm;
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer | Uint8Array, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer | Uint8Array,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     const view = pvtsutils.BufferSourceConverter.toUint8Array(inputBuffer);
+    const parseContext = context ?? createFromBerContext();
 
     // Basic check for parameters
     if (!checkBufferParams(this, view, inputOffset, inputLength)) {
@@ -66,7 +76,7 @@ export class LocalConstructedValueBlock extends ValueBlock implements ILocalCons
     let currentOffset = inputOffset;
 
     while (checkLen(this.isIndefiniteForm, inputLength) > 0) {
-      const returnObject = localFromBER(view, currentOffset, inputLength);
+      const returnObject = localFromBERWithChildContext(view, currentOffset, inputLength, parseContext);
       if (returnObject.offset === -1) {
         this.error = returnObject.result.error;
         this.warnings.concat(returnObject.result.warnings);

--- a/src/internals/LocalOctetStringValueBlock.ts
+++ b/src/internals/LocalOctetStringValueBlock.ts
@@ -3,6 +3,7 @@ import {
   HexBlockJson, HexBlockParams, HexBlock,
 } from "../HexBlock";
 import type { OctetString } from "../OctetString";
+import type { FromBerContext } from "../parser";
 import { END_OF_CONTENT_NAME, OCTET_STRING_NAME } from "./constants";
 import {
   LocalConstructedValueBlockParams, LocalConstructedValueBlockJson, LocalConstructedValueBlock,
@@ -34,13 +35,24 @@ export class LocalOctetStringValueBlock extends HexBlock(LocalConstructedValueBl
     this.isConstructed = isConstructed;
   }
 
-  public override fromBER(inputBuffer: ArrayBuffer, inputOffset: number, inputLength: number): number {
+  public override fromBER(
+    inputBuffer: ArrayBuffer,
+    inputOffset: number,
+    inputLength: number,
+    context?: FromBerContext,
+  ): number {
     let resultOffset = 0;
 
     if (this.isConstructed) {
       this.isHexOnly = false;
 
-      resultOffset = LocalConstructedValueBlock.prototype.fromBER.call(this, inputBuffer, inputOffset, inputLength);
+      resultOffset = LocalConstructedValueBlock.prototype.fromBER.call(
+        this,
+        inputBuffer,
+        inputOffset,
+        inputLength,
+        context,
+      );
       if (resultOffset === -1)
         return resultOffset;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,6 +10,85 @@ export interface FromBerResult {
   result: AsnType;
 }
 
+export interface FromBerOptions {
+  maxDepth?: number;
+  maxNodes?: number;
+  maxContentLength?: number;
+}
+
+export interface FromBerContext {
+  depth: number;
+  maxDepth: number;
+  nodesCount: number;
+  maxNodes: number;
+  maxContentLength: number;
+}
+
+export const DEFAULT_MAX_DEPTH = 100;
+export const DEFAULT_MAX_NODES = 10000;
+export const DEFAULT_MAX_CONTENT_LENGTH = 16 * 1024 * 1024;
+
+export const MAX_DEPTH_EXCEEDED_ERROR = "Maximum ASN.1 nesting depth exceeded";
+export const MAX_NODES_EXCEEDED_ERROR = "Maximum ASN.1 node count exceeded";
+export const MAX_CONTENT_LENGTH_EXCEEDED_ERROR = "Maximum ASN.1 content length exceeded";
+
+export function createFromBerContext(options: FromBerOptions = {}): FromBerContext {
+  return {
+    depth: 0,
+    maxDepth: options.maxDepth ?? DEFAULT_MAX_DEPTH,
+    nodesCount: 0,
+    maxNodes: options.maxNodes ?? DEFAULT_MAX_NODES,
+    maxContentLength: options.maxContentLength ?? DEFAULT_MAX_CONTENT_LENGTH,
+  };
+}
+
+function createErrorResult(error: string): FromBerResult {
+  const result = new BaseBlock({}, ValueBlock);
+  result.error = error;
+
+  return {
+    offset: -1,
+    result,
+  };
+}
+
+function checkNodesLimit(context: FromBerContext): string | undefined {
+  context.nodesCount += 1;
+  if (context.nodesCount > context.maxNodes) {
+    return MAX_NODES_EXCEEDED_ERROR;
+  }
+
+  return undefined;
+}
+
+function checkContentLengthLimit(inputLength: number, context: FromBerContext): string | undefined {
+  if (inputLength > context.maxContentLength) {
+    return MAX_CONTENT_LENGTH_EXCEEDED_ERROR;
+  }
+
+  return undefined;
+}
+
+export function localFromBERWithChildContext(
+  inputBuffer: Uint8Array,
+  inputOffset: number,
+  inputLength: number,
+  context: FromBerContext,
+): FromBerResult {
+  const childDepth = context.depth + 1;
+  if (childDepth > context.maxDepth) {
+    return createErrorResult(MAX_DEPTH_EXCEEDED_ERROR);
+  }
+
+  context.depth = childDepth;
+
+  try {
+    return localFromBER(inputBuffer, inputOffset, inputLength, context);
+  } finally {
+    context.depth -= 1;
+  }
+}
+
 /**
  * Local function changing a type for ASN.1 classes
  * @param inputObject Incoming object
@@ -41,6 +120,7 @@ export function localFromBER(
   inputBuffer: Uint8Array,
   inputOffset = 0,
   inputLength = inputBuffer.length,
+  context: FromBerContext = createFromBerContext(),
 ): FromBerResult {
   const incomingOffset = inputOffset; // Need to store initial offset since "inputOffset" is changing in the function
 
@@ -64,6 +144,16 @@ export function localFromBER(
   // Initial checks
   if (!intBuffer.length) {
     returnObject.error = "Zero buffer length";
+
+    return {
+      offset: -1,
+      result: returnObject,
+    };
+  }
+
+  const nodesLimitError = checkNodesLimit(context);
+  if (nodesLimitError) {
+    returnObject.error = nodesLimitError;
 
     return {
       offset: -1,
@@ -108,6 +198,17 @@ export function localFromBER(
 
   inputOffset = resultOffset;
   inputLength -= returnObject.lenBlock.blockLength;
+
+  const valueLength = returnObject.lenBlock.isIndefiniteForm ? inputLength : returnObject.lenBlock.length;
+  const contentLengthError = checkContentLengthLimit(valueLength, context);
+  if (contentLengthError) {
+    returnObject.error = contentLengthError;
+
+    return {
+      offset: -1,
+      result: returnObject,
+    };
+  }
 
   // Check for using indefinite length form in encoding for primitive types
   if (!returnObject.idBlock.isConstructed
@@ -276,7 +377,8 @@ export function localFromBER(
   resultOffset = returnObject.fromBER(
     inputBuffer,
     inputOffset,
-    returnObject.lenBlock.isIndefiniteForm ? inputLength : returnObject.lenBlock.length,
+    valueLength,
+    context,
   );
 
   // Coping incoming buffer for entire ASN.1 block
@@ -292,8 +394,9 @@ export function localFromBER(
 /**
  * Major function for decoding ASN.1 BER array into internal library structures
  * @param inputBuffer ASN.1 BER encoded array of bytes
+ * @param options Parser resource limits for untrusted input
  */
-export function fromBER(inputBuffer: pvtsutils.BufferSource): FromBerResult {
+export function fromBER(inputBuffer: pvtsutils.BufferSource, options: FromBerOptions = {}): FromBerResult {
   if (!inputBuffer.byteLength) {
     const result = new BaseBlock({}, ValueBlock);
     result.error = "Input buffer has zero length";
@@ -304,5 +407,10 @@ export function fromBER(inputBuffer: pvtsutils.BufferSource): FromBerResult {
     };
   }
 
-  return localFromBER(pvtsutils.BufferSourceConverter.toUint8Array(inputBuffer).slice(), 0, inputBuffer.byteLength);
+  return localFromBER(
+    pvtsutils.BufferSourceConverter.toUint8Array(inputBuffer).slice(),
+    0,
+    inputBuffer.byteLength,
+    createFromBerContext(options),
+  );
 }

--- a/test/unitTests.spec.ts
+++ b/test/unitTests.spec.ts
@@ -4,6 +4,75 @@ import * as asn1js from "../src";
 import { BaseBlock } from "../src";
 import { checkBufferParams } from "../src/internals/utils";
 
+const certB64 = "MIIDLjCCAhagAwIBAgIBATANBgkqhkiG9w0BAQsFADA6MRkwFwYDVQQDExBUZXN0IGNlcnRpZmljYXRlMR0wGwYJKoZIhvcNAQkBFg5zb21lQGVtYWlsLm5ldDAeFw0yMTAzMTYwMDAwMDBaFw0yMTA0MTYwMDAwMDBaMDoxGTAXBgNVBAMTEFRlc3QgY2VydGlmaWNhdGUxHTAbBgkqhkiG9w0BCQEWDnNvbWVAZW1haWwubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3N6J0GUJ8URj2fduC26mjCzWf75jM3QSLQYiXSTAMqJA9apf09GMmT+UC6jq2J1U49mXGezE64uXv2tyys9S07xgRkNAWPJXz0opKYud4XPEpdxKfQkD2XklK+8R3BPhAOOxSpfR+SFkLxTMiDHsOt+Xbb98DZ8F3QkzHLvX42jEfAR0StIRLgFYEtf4vX9q4OsYTeJ4xk61lTJc3d0ep/JTp55fxWRaQdzhg+fkv9XwJxxhW9pJRekZORnRb4Q1Zyw+uecuIffsmhLzang45npfzAKXuPaE6lnRMHauLQ1rGGqYA/Vaq4UU6yZUTVLpsKON7b1xogMQrqIkbqtTuQIDAQABoz8wPTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIEkDAdBgNVHQ4EFgQUl4hohjz9Xxb4lYhsOiq9wVqKv8YwDQYJKoZIhvcNAQELBQADggEBAIKH86qkFJV3FZyblAMWDSEbEi4MV2Epb5ty7wpSatHvz8NKtmB/hVFGwWFBj5OfS9wfaX6Uw24DyBSBOOqEzonUeqFTDo54zqQ4fQ+UlC/79aq7awGpEuXFnUF3xiLFqHNz5zUeKEYY0W5XKFg/TiW6hAmxlDg5ybAoHDROpwT4u6TuOK6OxMneQRBESmZlO43DYwCG950fXEDJT2gXVLbbSSTln8JBHfTAwOgmsDtaZOCieTS6KYwscWy3u/8xxMyX8NS3A1Zeh0jtk/irKzfsNAdcl8aQwdckGAkPWT/9EqawC33Ep3+2br41+K1jjGT8LeYDlMYSJycWo9tltKc=";
+
+function concatArrays(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, array) => sum + array.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const array of arrays) {
+    result.set(array, offset);
+    offset += array.length;
+  }
+
+  return result;
+}
+
+function encodeLength(length: number): Uint8Array {
+  if (length < 0x80) {
+    return Uint8Array.of(length);
+  }
+
+  const bytes = [];
+  let value = length;
+  while (value > 0) {
+    bytes.unshift(value & 0xff);
+    value >>= 8;
+  }
+
+  return Uint8Array.of(0x80 | bytes.length, ...bytes);
+}
+
+function wrapSequence(content: Uint8Array): Uint8Array {
+  return concatArrays(Uint8Array.of(0x30), encodeLength(content.length), content);
+}
+
+function wrapIndefiniteSequence(content: Uint8Array): Uint8Array {
+  return concatArrays(Uint8Array.of(0x30, 0x80), content, Uint8Array.of(0x00, 0x00));
+}
+
+function makeNestedSequence(depth: number): Uint8Array {
+  let current: Uint8Array = Uint8Array.of(0x05, 0x00);
+  for (let index = 0; index < depth; index += 1) {
+    current = wrapSequence(current);
+  }
+
+  return current;
+}
+
+function makeNestedIndefiniteSequence(depth: number): Uint8Array {
+  let current: Uint8Array = Uint8Array.of(0x05, 0x00);
+  for (let index = 0; index < depth; index += 1) {
+    current = wrapIndefiniteSequence(current);
+  }
+
+  return current;
+}
+
+function makeSequenceOfNulls(count: number, isIndefiniteForm = false): Uint8Array {
+  const items = new Array<Uint8Array>(count).fill(Uint8Array.of(0x05, 0x00));
+  const content = concatArrays(...items);
+
+  return isIndefiniteForm
+    ? concatArrays(Uint8Array.of(0x30, 0x80), content, Uint8Array.of(0x00, 0x00))
+    : wrapSequence(content);
+}
+
+function makeOctetString(length: number): Uint8Array {
+  return concatArrays(Uint8Array.of(0x04), encodeLength(length), new Uint8Array(length));
+}
+
 describe("Unit tests", () => {
   describe("utils", () => {
     it("buffer incorrect type", () => {
@@ -96,10 +165,101 @@ describe("Unit tests", () => {
   });
 
   it("toString", () => {
-    const certB64 = "MIIDLjCCAhagAwIBAgIBATANBgkqhkiG9w0BAQsFADA6MRkwFwYDVQQDExBUZXN0IGNlcnRpZmljYXRlMR0wGwYJKoZIhvcNAQkBFg5zb21lQGVtYWlsLm5ldDAeFw0yMTAzMTYwMDAwMDBaFw0yMTA0MTYwMDAwMDBaMDoxGTAXBgNVBAMTEFRlc3QgY2VydGlmaWNhdGUxHTAbBgkqhkiG9w0BCQEWDnNvbWVAZW1haWwubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3N6J0GUJ8URj2fduC26mjCzWf75jM3QSLQYiXSTAMqJA9apf09GMmT+UC6jq2J1U49mXGezE64uXv2tyys9S07xgRkNAWPJXz0opKYud4XPEpdxKfQkD2XklK+8R3BPhAOOxSpfR+SFkLxTMiDHsOt+Xbb98DZ8F3QkzHLvX42jEfAR0StIRLgFYEtf4vX9q4OsYTeJ4xk61lTJc3d0ep/JTp55fxWRaQdzhg+fkv9XwJxxhW9pJRekZORnRb4Q1Zyw+uecuIffsmhLzang45npfzAKXuPaE6lnRMHauLQ1rGGqYA/Vaq4UU6yZUTVLpsKON7b1xogMQrqIkbqtTuQIDAQABoz8wPTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIEkDAdBgNVHQ4EFgQUl4hohjz9Xxb4lYhsOiq9wVqKv8YwDQYJKoZIhvcNAQELBQADggEBAIKH86qkFJV3FZyblAMWDSEbEi4MV2Epb5ty7wpSatHvz8NKtmB/hVFGwWFBj5OfS9wfaX6Uw24DyBSBOOqEzonUeqFTDo54zqQ4fQ+UlC/79aq7awGpEuXFnUF3xiLFqHNz5zUeKEYY0W5XKFg/TiW6hAmxlDg5ybAoHDROpwT4u6TuOK6OxMneQRBESmZlO43DYwCG950fXEDJT2gXVLbbSSTln8JBHfTAwOgmsDtaZOCieTS6KYwscWy3u/8xxMyX8NS3A1Zeh0jtk/irKzfsNAdcl8aQwdckGAkPWT/9EqawC33Ep3+2br41+K1jjGT8LeYDlMYSJycWo9tltKc=";
     const { result } = asn1js.fromBER(new Uint8Array(Buffer.from(certB64, "base64")).buffer);
     const asnString = result.toString();
     // console.log(asnString);
     assert.strictEqual(asnString.length > 0, true);
+  });
+
+  describe("fromBER resource limits", () => {
+    it("parses regular ASN.1 with explicit limits", () => {
+      const certificate = new Uint8Array(Buffer.from(certB64, "base64"));
+      const result = asn1js.fromBER(certificate, {
+        maxDepth: 32,
+        maxNodes: 512,
+        maxContentLength: 64 * 1024,
+      });
+
+      assert.notEqual(result.offset, -1, "Certificate should parse within configured limits");
+    });
+
+    it("returns a controlled error when maxDepth is exceeded", () => {
+      const result = asn1js.fromBER(makeNestedSequence(11), {
+        maxDepth: 10,
+        maxNodes: 64,
+        maxContentLength: 4096,
+      });
+
+      assert.equal(result.offset, -1, "Deep nesting should fail");
+      assert.equal(result.result.error, "Maximum ASN.1 nesting depth exceeded");
+    });
+
+    it("stops very deep inputs before the JavaScript stack overflows", () => {
+      assert.doesNotThrow(() => {
+        const result = asn1js.fromBER(makeNestedSequence(2000), {
+          maxDepth: 100,
+          maxNodes: 5000,
+          maxContentLength: 1024 * 1024,
+        });
+
+        assert.equal(result.offset, -1, "Very deep nesting should fail with a parse error");
+        assert.equal(result.result.error, "Maximum ASN.1 nesting depth exceeded");
+      });
+    });
+
+    it("returns a controlled error when maxNodes is exceeded", () => {
+      const result = asn1js.fromBER(makeSequenceOfNulls(6), {
+        maxDepth: 8,
+        maxNodes: 6,
+        maxContentLength: 4096,
+      });
+
+      assert.equal(result.offset, -1, "Wide input should fail once node budget is exhausted");
+      assert.equal(result.result.error, "Maximum ASN.1 node count exceeded");
+    });
+
+    it("returns a controlled error when primitive content exceeds maxContentLength", () => {
+      const result = asn1js.fromBER(makeOctetString(5), {
+        maxDepth: 8,
+        maxNodes: 32,
+        maxContentLength: 4,
+      });
+
+      assert.equal(result.offset, -1, "Primitive content length limit should be enforced");
+      assert.equal(result.result.error, "Maximum ASN.1 content length exceeded");
+    });
+
+    it("returns a controlled error when constructed content exceeds maxContentLength", () => {
+      const result = asn1js.fromBER(makeSequenceOfNulls(3), {
+        maxDepth: 8,
+        maxNodes: 32,
+        maxContentLength: 5,
+      });
+
+      assert.equal(result.offset, -1, "Constructed content length limit should be enforced");
+      assert.equal(result.result.error, "Maximum ASN.1 content length exceeded");
+    });
+
+    it("applies maxDepth to indefinite-length constructed input", () => {
+      const result = asn1js.fromBER(makeNestedIndefiniteSequence(11), {
+        maxDepth: 10,
+        maxNodes: 64,
+        maxContentLength: 4096,
+      });
+
+      assert.equal(result.offset, -1, "Indefinite nested input should fail by depth");
+      assert.equal(result.result.error, "Maximum ASN.1 nesting depth exceeded");
+    });
+
+    it("applies maxNodes to indefinite-length constructed input", () => {
+      const result = asn1js.fromBER(makeSequenceOfNulls(6, true), {
+        maxDepth: 8,
+        maxNodes: 6,
+        maxContentLength: 4096,
+      });
+
+      assert.equal(result.offset, -1, "Indefinite wide input should fail by node count");
+      assert.equal(result.result.error, "Maximum ASN.1 node count exceeded");
+    });
   });
 });


### PR DESCRIPTION
## Summary

This change hardens BER parsing for untrusted ASN.1 input by adding configurable parser resource limits to `fromBER()` and propagating a shared parse context through recursive decode paths.

## What changed

- Added `FromBerOptions` with `maxDepth`, `maxNodes`, and `maxContentLength`.
- Kept backward compatibility for the existing `fromBER(buffer)` call.
- Introduced default safe limits:
  - `maxDepth = 100`
  - `maxNodes = 10000`
  - `maxContentLength = 16 MiB`
- Added a shared mutable parse context so node counting is enforced across the full parse session.
- Enforced a controlled parse error before recursive descent when nesting exceeds the configured depth.
- Enforced node-count limits for wide trees.
- Enforced content-length limits for definite-length and `indefinite length` constructed content.
- Applied the same protections to recursive parsing used by constructed values and embedded ASN.1 probing in `BIT STRING` and `OCTET STRING`.
- Exported the new public `fromBER()` options and documented them in `README.md`.

## Error behavior

On budget exhaustion the parser now returns normal `FromBerResult` failures instead of allowing runtime crashes. New error messages include:

- `Maximum ASN.1 nesting depth exceeded`
- `Maximum ASN.1 node count exceeded`
- `Maximum ASN.1 content length exceeded`

## Tests

Added regression coverage for:

- normal parsing with explicit limits
- depth-limit enforcement
- very deep valid BER input without stack overflow
- node-count enforcement on wide inputs
- content-length enforcement for primitive and constructed values
- `indefinite length` depth and node-count enforcement

## Validation

- `npm test`
- `npm run build`
- `npm run lint`

## Backward compatibility

- Existing `fromBER(buffer)` usage remains valid.
- Errors continue to flow through `FromBerResult` rather than new thrown exceptions.
