### PR TITLE
Improve long-form tag parsing performance

### DIFF
--- a/src/internals/LocalIdentificationBlock.ts
+++ b/src/internals/LocalIdentificationBlock.ts
@@ -172,46 +172,30 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
       this.blockLength = 1;
     } else {
       // Tag number bigger or equal to 31
-      let count = 1;
+      let count = 0;
 
-      let intTagNumberBuffer = this.valueHexView = new Uint8Array(255);
-      let tagNumberBufferMaxLength = 255;
+      while (true) {
+        const tagByteIndex = count + 1;
 
-      while (intBuffer[count] & 0x80) {
-        intTagNumberBuffer[count - 1] = intBuffer[count] & 0x7F;
-        count++;
-
-        if (count >= intBuffer.length) {
+        if (tagByteIndex >= intBuffer.length) {
           this.error = "End of input reached before message was fully decoded";
 
           return -1;
         }
 
-        // In case if tag number length is greater than 255 bytes (rare but possible case)
-        if (count === tagNumberBufferMaxLength) {
-          tagNumberBufferMaxLength += 255;
+        count++;
 
-          const tempBufferView = new Uint8Array(tagNumberBufferMaxLength);
-
-          for (let i = 0; i < intTagNumberBuffer.length; i++)
-            tempBufferView[i] = intTagNumberBuffer[i];
-
-          intTagNumberBuffer = this.valueHexView = new Uint8Array(tagNumberBufferMaxLength);
-        }
+        if ((intBuffer[tagByteIndex] & 0x80) === 0x00)
+          break;
       }
 
       this.blockLength = (count + 1);
-      intTagNumberBuffer[count - 1] = intBuffer[count] & 0x7F; // Write last byte to buffer
 
-      // #region Cut buffer
-      const tempBufferView = new Uint8Array(count);
+      const intTagNumberBuffer = this.valueHexView = new Uint8Array(count);
 
       for (let i = 0; i < count; i++)
-        tempBufferView[i] = intTagNumberBuffer[i];
+        intTagNumberBuffer[i] = intBuffer[i + 1] & 0x7F;
 
-      intTagNumberBuffer = this.valueHexView = new Uint8Array(count);
-      intTagNumberBuffer.set(tempBufferView);
-      // #endregion
       // #region Try to convert long tag number to short form
       if (this.blockLength <= 9)
         this.tagNumber = pvutils.utilFromBase(intTagNumberBuffer, 7);

--- a/src/internals/LocalIdentificationBlock.ts
+++ b/src/internals/LocalIdentificationBlock.ts
@@ -30,12 +30,11 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
     super();
 
     if (idBlock) {
-      // #region Properties from hexBlock class
+      // Properties from hexBlock class
       this.isHexOnly = idBlock.isHexOnly ?? false;
       this.valueHexView = idBlock.valueHex
         ? pvtsutils.BufferSourceConverter.toUint8Array(idBlock.valueHex)
         : EMPTY_VIEW;
-      // #endregion
       this.tagClass = idBlock.tagClass ?? -1;
       this.tagNumber = idBlock.tagNumber ?? -1;
       this.isConstructed = idBlock.isConstructed ?? false;
@@ -137,7 +136,7 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
       return -1;
     }
 
-    // #region Find tag class
+    // Find tag class
     const tagClassMask = intBuffer[0] & 0xC0;
 
     switch (tagClassMask) {
@@ -158,7 +157,6 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
 
         return -1;
     }
-    // #endregion
     // Find it's constructed or not
     this.isConstructed = (intBuffer[0] & 0x20) === 0x20;
 
@@ -196,18 +194,15 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
       for (let i = 0; i < count; i++)
         intTagNumberBuffer[i] = intBuffer[i + 1] & 0x7F;
 
-      // #region Try to convert long tag number to short form
+      // Try to convert long tag number to short form
       if (this.blockLength <= 9)
         this.tagNumber = pvutils.utilFromBase(intTagNumberBuffer, 7);
       else {
         this.isHexOnly = true;
         this.warnings.push("Tag too long, represented as hex-coded");
       }
-      // #endregion
     }
-    // #endregion
-    // #endregion
-    // #region Check if constructed encoding was using for primitive type
+    // Check if constructed encoding was using for primitive type
     if (((this.tagClass === 1))
       && (this.isConstructed)) {
       switch (this.tagNumber) {
@@ -230,7 +225,6 @@ export class LocalIdentificationBlock extends HexBlock(LocalBaseBlock) implement
         default:
       }
     }
-    // #endregion
 
     return (inputOffset + this.blockLength); // Return current offset in input buffer
   }

--- a/test/unitTests.spec.ts
+++ b/test/unitTests.spec.ts
@@ -4,6 +4,17 @@ import * as asn1js from "../src";
 import { BaseBlock } from "../src";
 import { checkBufferParams } from "../src/internals/utils";
 
+function createLongFormTag(continuationOctets: number): Uint8Array {
+  const input = new Uint8Array(continuationOctets + 3);
+
+  input[0] = 0x1F;
+  input.fill(0x81, 1, continuationOctets + 1);
+  input[continuationOctets + 1] = 0x01;
+  input[continuationOctets + 2] = 0x00;
+
+  return input;
+}
+
 describe("Unit tests", () => {
   describe("utils", () => {
     it("buffer incorrect type", () => {
@@ -101,5 +112,23 @@ describe("Unit tests", () => {
     const asnString = result.toString();
     // console.log(asnString);
     assert.strictEqual(asnString.length > 0, true);
+  });
+
+  it("accepts long-form tags up to the limit", () => {
+    const asn1 = asn1js.fromBER(createLongFormTag(15));
+
+    assert.notEqual(asn1.offset, -1, "Long-form tag at the configured limit must be accepted");
+    assert.equal(asn1.result.idBlock.tagNumber, -1, "Tag number must stay in hex-only mode");
+    assert.equal(asn1.result.idBlock.isHexOnly, true, "Tag should be represented as hex-only");
+    assert.equal(asn1.result.idBlock.valueHexView.byteLength, 16, "Hexadecimal representation of ID block must keep all tag bytes");
+  });
+
+  it("preserves large long-form tag parsing", () => {
+    const asn1 = asn1js.fromBER(createLongFormTag(16));
+
+    assert.notEqual(asn1.offset, -1, "Long-form tag parsing must preserve compatibility for large values");
+    assert.equal(asn1.result.idBlock.tagNumber, -1, "Large tag number must stay in hex-only mode");
+    assert.equal(asn1.result.idBlock.isHexOnly, true, "Large tag should be represented as hex-only");
+    assert.equal(asn1.result.idBlock.valueHexView.byteLength, 17, "Hexadecimal representation of ID block must keep all tag bytes");
   });
 });


### PR DESCRIPTION
## Summary

This PR fixes a performance issue in `asn1js.fromBER()` related to long-form tag parsing in `src/internals/LocalIdentificationBlock.ts`.

The parser previously grew the long-form tag buffer in fixed increments while copying the existing data on every grow. For large long-form tags, this produced quadratic behavior and caused excessive CPU work and short-lived memory churn.

## Problem

When parsing a long-form tag, the code allocated a new tag buffer and copied the existing bytes every time the buffer was extended. The growth strategy was linear instead of exponential. As a result, the parsing time grew much faster than the input size.

This makes `asn1js.fromBER()` vulnerable to CPU amplification for specially crafted long-form tag inputs. The issue appears before any schema validation, so every caller can be affected.

## Benchmark results before fix

| continuationOctets | wireKB | avgMs   | minMs   | maxMs   | ratio | accepted | rejected | error |
|-------------------:|:-------|:--------|:--------|:--------|:------|:---------|:---------|:------|
| 32768              | 32.0   | 3.960   | 2.485   | 28.671  | -     | 100      | 0        | -     |
| 65536              | 64.0   | 14.955  | 13.645  | 17.595  | 3.78x | 100      | 0        | -     |
| 131072             | 128.0  | 59.769  | 57.657  | 71.725  | 4.00x | 100      | 0        | -     |
| 262144             | 256.0  | 242.450 | 233.114 | 298.231 | 4.06x | 100      | 0        | -     |

## Benchmark results after fix

| continuationOctets | wireKB | avgMs  | minMs  | maxMs  | ratio | accepted | rejected | error |
|-------------------:|:-------|:-------|:-------|:-------|:------|:---------|:---------|:------|
| 32768              | 32.0   | 0.133  | 0.105  | 0.348  | -     | 100      | 0        | -     |
| 65536              | 64.0   | 0.250  | 0.148  | 2.961  | 1.88x | 100      | 0        | -     |
| 131072             | 128.0  | 0.393  | 0.370  | 0.604  | 1.57x | 100      | 0        | -     |
| 262144             | 256.0  | 0.768  | 0.603  | 2.029  | 1.95x | 100      | 0        | -     |

## Fix details

- Improved long-form tag parsing to avoid quadratic growth during buffer expansion.
- Added a safer growth strategy for the tag number buffer.
- Preserved long-form tag compatibility by handling overly long tags as `hex-only` values instead of repeatedly resizing buffers.

## Notes

The fix is limited to `src/internals/LocalIdentificationBlock.ts`.