### PR TITLE
ci(release): align Trusted Publisher flow with PKI.js

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,60 @@
-name: Node.js Package
+name: Release
+
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
-  id-token: write
   contents: write
-  packages: write
+  id-token: write
 
 jobs:
-  publish:
+  prepare-release:
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_tag: ${{ steps.version.outputs.major_tag }}
+      tgz: ${{ steps.pack.outputs.tgz }}
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout default branch
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
         with:
-          node-version: "24"
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Bump version without git tag
+        id: version
+        run: |
+          npm version "${{ inputs.version }}" --no-git-tag-version
+
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(node -p "require('./package.json').version.split('.')[0]")
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major_tag=v$MAJOR" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: npm run build
@@ -32,15 +62,140 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Publish to NPM
-        run: npm publish --provenance --access public
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
+      - name: Pack release artifact
+        id: pack
+        run: |
+          TGZ=$(npm pack --ignore-scripts --json | node -e "let s='';process.stdin.on('data',d=>s+=d);process.stdin.on('end',()=>console.log(JSON.parse(s)[0].filename))")
+
+          echo "tgz=$TGZ" >> "$GITHUB_OUTPUT"
+          sha256sum "$TGZ" > "$TGZ.sha256"
+
+      - name: Generate release summary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          PREVIOUS_TAG=$(git tag --merged "$CURRENT_SHA" --sort=-version:refname | head -n 1)
+
+          echo "## Release preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** ${{ steps.version.outputs.release_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release type:** ${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Package:** \`${{ steps.pack.outputs.tgz }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### SHA256" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat "${{ steps.pack.outputs.tgz }}.sha256" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Changes" >> "$GITHUB_STEP_SUMMARY"
+
+          declare -A SEEN_PRS=()
+          if [ -n "$PREVIOUS_TAG" ]; then
+            COMMIT_RANGE="$PREVIOUS_TAG..$CURRENT_SHA"
+          else
+            COMMIT_RANGE="$CURRENT_SHA"
+          fi
+
+          while IFS= read -r COMMIT_SHA; do
+            [ -z "$COMMIT_SHA" ] && continue
+
+            COMMIT_SHORT_SHA=$(git rev-parse --short "$COMMIT_SHA")
+            COMMIT_SUBJECT=$(git show -s --format=%s "$COMMIT_SHA")
+            PR_JSON=$(gh api "repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" \
+              -H "Accept: application/vnd.github+json" 2>/dev/null || echo "")
+
+            if [ -n "$PR_JSON" ] && [ "$PR_JSON" != "[]" ]; then
+              PR_NUMBER=$(node -e 'const payload = JSON.parse(process.argv[1]); process.stdout.write(String(payload[0].number));' "$PR_JSON")
+
+              if [ -z "${SEEN_PRS[$PR_NUMBER]+x}" ]; then
+                PR_TITLE=$(node -e 'const payload = JSON.parse(process.argv[1]); process.stdout.write(payload[0].title);' "$PR_JSON")
+                PR_URL=$(node -e 'const payload = JSON.parse(process.argv[1]); process.stdout.write(payload[0].html_url);' "$PR_JSON")
+
+                echo "- PR #$PR_NUMBER: [$PR_TITLE]($PR_URL)" >> "$GITHUB_STEP_SUMMARY"
+                SEEN_PRS[$PR_NUMBER]=1
+              fi
+            else
+              echo "- $COMMIT_SUBJECT ($COMMIT_SHORT_SHA)" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done < <(git rev-list --reverse "$COMMIT_RANGE")
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "[View full diff](https://github.com/${{ github.repository }}/compare/$PREVIOUS_TAG...$CURRENT_SHA)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload release package
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-package
+          path: |
+            *.tgz
+            *.tgz.sha256
+          retention-days: 7
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: prepare-release
+    environment: npm
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Download release package
+        uses: actions/download-artifact@v7
+        with:
+          name: npm-package
+          path: ./release-package
+
+      - name: Verify package checksum
+        run: |
+          cd release-package
+          sha256sum -c *.tgz.sha256
+
+      - name: Publish prepared package via Trusted Publisher
+        run: npm publish ./release-package/*.tgz --access public
+
+      - name: Commit release version and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          npm version "${{ needs.prepare-release.outputs.version }}" --no-git-tag-version
+
+          git add package.json package-lock.json
+          git commit -m "chore(release): ${{ needs.prepare-release.outputs.release_tag }}"
+          git tag "${{ needs.prepare-release.outputs.release_tag }}"
+
+      - name: Push release commit and tag
+        run: |
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"
+          git push origin "${{ needs.prepare-release.outputs.release_tag }}"
+
+      - name: Update major tag
+        run: |
+          git tag -f "${{ needs.prepare-release.outputs.major_tag }}" "${{ needs.prepare-release.outputs.release_tag }}"
+          git push origin "${{ needs.prepare-release.outputs.major_tag }}" --force
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.prepare-release.outputs.release_tag }}" \
+            --verify-tag \
+            --title "${{ needs.prepare-release.outputs.release_tag }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

Implements #179 by aligning the ASN1.js release workflow with the Trusted Publisher release flow used in PKI.js.

## What changed

- Reworks `.github/workflows/publish.yml` from a tag-driven publisher into a manually triggered release workflow.
- Adds `workflow_dispatch` with `patch`, `minor`, and `major` release choices.
- Adds a `prepare-release` job that:
  - installs dependencies;
  - bumps the version without creating a tag;
  - builds and tests ASN1.js;
  - packs the exact npm tarball;
  - generates a SHA256 checksum;
  - produces a reviewer-friendly `GITHUB_STEP_SUMMARY` with release metadata and changes since the previous tag;
  - uploads the tarball and checksum as an artifact.
- Adds a protected `publish` job using GitHub Environment `npm` and `id-token: write` for npm Trusted Publisher/OIDC.
- Publishes the exact prepared tarball after verifying its checksum.
- Only after successful npm publication, commits the release version, pushes `vX.Y.Z`, updates `vX`, and creates the GitHub Release.

## Why

ASN1.js already used OIDC-based npm publishing, but release initiation was tag-driven and did not provide the same review/approval flow as PKI.js. This change makes the release artifact reviewable before publication and allows GitHub Environment protection rules / required reviewers to gate the publish step.

## Validation

- Compared against the current PKI.js `release.yml` implementation.
- Kept the existing workflow filename (`publish.yml`) to avoid unnecessarily changing the npm Trusted Publisher workflow identity.
- Preserved ASN1.js-specific release validation by running `npm test` before packing.
- Verified the resulting branch diff is limited to `.github/workflows/publish.yml` and is one commit ahead of `master`.
- YAML structure was parsed locally for syntax validation.

## Deployment note

The `asn1js` package on npmjs.com must have its GitHub Actions Trusted Publisher configured for this repository/workflow and the `npm` GitHub Environment. GitHub Environment protection rules can then be used to require reviewer approval before the publish job proceeds.

Closes #179